### PR TITLE
Creates basic REST endpoint to retrieve posts data

### DIFF
--- a/app/controllers/RestController.scala
+++ b/app/controllers/RestController.scala
@@ -1,0 +1,53 @@
+package controllers
+
+import models.Post
+import play.api.Configuration
+import play.api.cache.SyncCacheApi
+import play.api.mvc.{AbstractController, Action, AnyContent, ControllerComponents}
+import play.api.libs.json._
+
+import javax.inject.Inject
+
+class RestController @Inject()(
+                                controllerComponents: ControllerComponents,
+                                configuration: Configuration,
+                                cache: SyncCacheApi
+                              ) extends AbstractController(controllerComponents) {
+
+  def posts(limit: Int, page: Int, tag: Option[String], author: Option[String], lang: Option[String]): Action[AnyContent] = Action {
+    getPosts(tag, author) match {
+      case None =>
+        BadRequest("nothing in the cache")
+      case Some(posts) =>
+        val result = slicePosts(applyPostsFilters(posts, lang), limit, page).map(_.toJson)
+        Ok(Json.toJson(result))
+    }
+  }
+
+  private def getPosts(tag: Option[String], author: Option[String]) = {
+    def filterTags(posts: Option[Seq[Post]], tagName: String) = posts match {
+      case Some(postsVal) => Some(postsVal.filter(_.tags.exists(_.contains(tagName))))
+      case None => None
+    }
+
+    (tag, author) match {
+      case (Some(tagName), None) => cache.get[Seq[Post]]("tag-" + tagName)
+      case (None, Some(authorName)) => cache.get[Seq[Post]]("author-" + authorName)
+      case (Some(tagName), Some(authorName)) => filterTags(cache.get[Seq[Post]]("author-" + authorName), tagName)
+      case (None, None) => cache.get[Seq[Post]]("posts")
+    }
+  }
+
+  private def applyPostsFilters(posts: Seq[Post], lang: Option[String]) = {
+    def langFilter(input: Post) = lang match {
+      case Some(value) => input.lang == value
+      case None => true
+    }
+
+    posts.filter(langFilter)
+  }
+
+  private def slicePosts(posts: Seq[Post], limit: Int, page: Int) = {
+    posts.slice((page - 1) * limit, page * limit)
+  }
+}

--- a/conf/routes
+++ b/conf/routes
@@ -4,14 +4,17 @@
 # ~~~~
 
 # An example controller showing a sample home page
-GET     /                                         controllers.HomeController.index()
-GET     /posts/                                   controllers.HomeController.posts(page: Int ?= 1)
-GET     /feed/                                    controllers.HomeController.feed()
-GET     /posts/:name                              controllers.HomeController.view(name: String)
-GET     /author/:name                             controllers.HomeController.byAuthor(name: String)
-GET     /tags/:name                               controllers.HomeController.byTags(name: String)
-GET     /media/:post/:name                        controllers.HomeController.media(post: String, name: String)
-GET     /wp-json/wp/v2/posts                      controllers.HomeController.posts(page: Int ?= 1)
+GET        /                           controllers.HomeController.index()
+GET        /posts/                     controllers.HomeController.posts(page: Int ?= 1)
+GET        /feed/                      controllers.HomeController.feed()
+GET        /posts/:name                controllers.HomeController.view(name: String)
+GET        /author/:name               controllers.HomeController.byAuthor(name: String)
+GET        /tags/:name                 controllers.HomeController.byTags(name: String)
+GET        /media/:post/:name          controllers.HomeController.media(post: String, name: String)
+GET        /wp-json/wp/v2/posts        controllers.HomeController.posts(page: Int ?= 1)
+
+# Rest API
+GET        /api/posts                  controllers.RestController.posts(limit: Int ?= 10, page: Int ?= 1, tag: Option[String], author: Option[String], lang: Option[String])
 
 # Map static resources from the /public folder to the /assets URL path
-GET     /assets/*file               controllers.Assets.versioned(path="/public", file: Asset)
+GET        /assets/*file               controllers.Assets.versioned(path="/public", file: Asset)


### PR DESCRIPTION
This PR aims to provide a very basic REST endpoint that can be used to retrieve basic informations about the blog posts. I plan to then use this endpoint in a "possible" mobile app (more details in the coming days) to link users to interesting blog posts using the `post.slug` property

More filter could be provided to the end point (`from` and `to` filters could be used on the `publicationDate` for example) but I think that the existing ones cover the most common use cases